### PR TITLE
ci: add rc release workflow

### DIFF
--- a/.github/scripts/prepare-rc-release.js
+++ b/.github/scripts/prepare-rc-release.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+
+const CZ_TOML = '.cz.toml';
+const MAIN_REF = process.env.RC_BASE_REF || 'origin/main';
+const VALID_BUMPS = new Set(['major', 'minor', 'patch']);
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function readVersion(content) {
+  const match = content.match(/^version\s*=\s*"([^"]+)"/m);
+  if (!match) {
+    throw new Error('Could not find version in .cz.toml');
+  }
+  return match[1];
+}
+
+function parseVersion(version) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-rc\.\d+)?$/);
+  if (!match) {
+    throw new Error(`Unsupported version format: ${version}`);
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function formatVersion(version) {
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+function increment(version, bump) {
+  if (bump === 'major') {
+    return { major: version.major + 1, minor: 0, patch: 0 };
+  }
+  if (bump === 'minor') {
+    return { major: version.major, minor: version.minor + 1, patch: 0 };
+  }
+  return { major: version.major, minor: version.minor, patch: version.patch + 1 };
+}
+
+function commitMessagesSince(ref) {
+  return git(['log', '--format=%B%x00', `${ref}..HEAD`])
+    .split('\0')
+    .map((message) => message.trim())
+    .filter(Boolean)
+    .filter((message) => !message.startsWith('chore: release '));
+}
+
+function bumpFromMessages(messages) {
+  const explicit = process.env.RC_BUMP;
+  if (explicit) {
+    if (!VALID_BUMPS.has(explicit)) {
+      throw new Error(`RC_BUMP must be one of: ${Array.from(VALID_BUMPS).join(', ')}`);
+    }
+    return explicit;
+  }
+
+  let bump = null;
+  for (const message of messages) {
+    const header = message.split(/\r?\n/, 1)[0];
+    if (/BREAKING CHANGE:/m.test(message) || /^[a-zA-Z]+(?:\([^)]*\))?!:/.test(header)) {
+      return 'major';
+    }
+    if (/^feat(?:\([^)]*\))?:/.test(header)) {
+      bump = bump === 'patch' || bump == null ? 'minor' : bump;
+    } else if (/^fix(?:\([^)]*\))?:/.test(header) && bump == null) {
+      bump = 'patch';
+    } else if (bump == null) {
+      bump = 'patch';
+    }
+  }
+
+  return bump || 'patch';
+}
+
+function latestRc(base) {
+  const output = git(['tag', '--list', `v${base}-rc.*`]);
+  if (!output) {
+    return 0;
+  }
+  return output
+    .split(/\r?\n/)
+    .map((tag) => tag.match(new RegExp(`^v${base.replaceAll('.', '\\.')}-rc\\.(\\d+)$`)))
+    .filter(Boolean)
+    .map((match) => Number(match[1]))
+    .reduce((max, value) => Math.max(max, value), 0);
+}
+
+function versionFromRef(ref) {
+  const content = git(['show', `${ref}:${CZ_TOML}`]);
+  return parseVersion(readVersion(content));
+}
+
+const currentContent = fs.readFileSync(CZ_TOML, 'utf8');
+const baseVersion = versionFromRef(MAIN_REF);
+const messages = commitMessagesSince(MAIN_REF);
+const bump = bumpFromMessages(messages);
+const targetBase = formatVersion(increment(baseVersion, bump));
+const nextVersion = `${targetBase}-rc.${latestRc(targetBase) + 1}`;
+
+const nextContent = currentContent.replace(
+  /^version\s*=\s*"[^"]+"/m,
+  `version = "${nextVersion}"`,
+);
+fs.writeFileSync(CZ_TOML, nextContent);
+
+console.log(`Base ref: ${MAIN_REF}`);
+console.log(`Base version: ${formatVersion(baseVersion)}`);
+console.log(`Aggregate bump: ${bump}`);
+console.log(`Next RC version: ${nextVersion}`);
+
+if (process.env.GITHUB_OUTPUT) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${nextVersion}\n`);
+}

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,0 +1,130 @@
+name: Release RC
+
+on:
+  push:
+    branches:
+      - next
+    paths:
+      - '.cz.toml'
+      - 'build.gradle'
+      - 'settings.gradle'
+      - 'gradle.properties'
+      - 'gradle/wrapper/**'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'src/**'
+
+env:
+  CI: true
+  GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+
+jobs:
+  ReleaseRC:
+    if: "${{ startsWith(github.event.head_commit.message, 'chore: release ') == false }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.WORKFLOW_PAT }}
+
+      - name: Fetch main and tags
+        run: git fetch origin main:refs/remotes/origin/main --tags
+
+      - name: Check out blue-quickjs
+        uses: actions/checkout@v4
+        with:
+          repository: bluecontract/blue-quickjs
+          path: blue-quickjs
+          submodules: recursive
+
+      - name: Set up Java 8 test runtime
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'corretto'
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v3
+        with:
+          java-version: '25'
+          distribution: 'corretto'
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.8.0
+          run_install: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'blue-quickjs/.nvmrc'
+          cache: 'pnpm'
+          cache-dependency-path: 'blue-quickjs/pnpm-lock.yaml'
+
+      - name: Cache emsdk
+        uses: actions/cache@v4
+        with:
+          path: blue-quickjs/tools/emsdk
+          key: emsdk-${{ runner.os }}-${{ hashFiles('blue-quickjs/tools/scripts/emsdk-version.txt') }}
+
+      - name: Install blue-quickjs dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: blue-quickjs
+
+      - name: Install emsdk
+        run: bash tools/scripts/setup-emsdk.sh
+        working-directory: blue-quickjs
+
+      - name: Build blue-quickjs runtime
+        run: pnpm exec nx build quickjs-runtime
+        working-directory: blue-quickjs
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Prepare RC version
+        id: version
+        run: node .github/scripts/prepare-rc-release.js
+
+      - name: Commit and tag RC version
+        run: |
+          git add .cz.toml
+          git commit -m "chore: release ${{ steps.version.outputs.version }}"
+          git tag -a "v${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
+
+      - name: Execute Gradle build
+        run: ./gradlew clean build -Dblue.quickjs.root="$GITHUB_WORKSPACE/blue-quickjs"
+
+      - name: Execute Gradle publish
+        run: ./gradlew publish -Dblue.quickjs.root="$GITHUB_WORKSPACE/blue-quickjs"
+
+      - name: Execute Gradle release
+        env:
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.MAVENCENTRAL_USERNAME }}
+          JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.MAVENCENTRAL_PASSWORD }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+        run: ./gradlew jreleaserFullRelease
+
+      - name: Push release commit and tag
+        run: git push origin HEAD:next --follow-tags
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: rc-artifacts
+          path: |
+            build/libs
+            build/publications
+            build/jreleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.WORKFLOW_PAT }}
 
       - name: Check if branch is main
         run: |
@@ -77,7 +77,7 @@ jobs:
 
       - name: Execute Gradle release
         env:
-          JRELEASER_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.MAVENCENTRAL_USERNAME }}
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.MAVENCENTRAL_PASSWORD }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
## Summary
- add a push-to-next RC release workflow for blue-coordination-java
- add the RC version preparation script used by the workflow
- mirror the blue-repository-java RC release behavior while preserving coordination's blue-quickjs build setup

## Validation
- node --check .github/scripts/prepare-rc-release.js
- git diff --check
- git diff --cached --check

## Notes
- origin/next was created from origin/main before this workflow exists so branch creation does not trigger an RC release.