### PR TITLE
fix(coordination): normalize resolved static patches

### DIFF
--- a/src/main/java/blue/coordination/processor/workflow/UpdateDocumentStepExecutor.java
+++ b/src/main/java/blue/coordination/processor/workflow/UpdateDocumentStepExecutor.java
@@ -5,6 +5,7 @@ import blue.language.model.Node;
 import blue.language.processor.WorkingDocument;
 import blue.language.processor.model.JsonPatch;
 import blue.language.snapshot.FrozenNode;
+import blue.language.utils.MergeReverser;
 import blue.repo.coordination.SequentialWorkflowStep;
 import blue.repo.coordination.UpdateDocument;
 import java.lang.reflect.Method;
@@ -68,6 +69,21 @@ public final class UpdateDocumentStepExecutor implements WorkflowStepExecutor<Up
     }
 
     private List<WorkflowPatchEntry> literalChangeset(UpdateDocument step, StepExecutionContext context) {
+        FrozenNode frozenChangeset = FrozenNodeUtil.property(context.stepFrozenNode(), "changeset");
+        if (frozenChangeset != null && frozenChangeset.getItems() != null) {
+            List<WorkflowPatchEntry> entries =
+                    new ArrayList<WorkflowPatchEntry>(frozenChangeset.getItems().size());
+            MergeReverser mergeReverser = new MergeReverser();
+            for (int i = 0; i < frozenChangeset.getItems().size(); i++) {
+                FrozenNode item = frozenChangeset.getItems().get(i);
+                Node literal = item == null ? null : item.toNode();
+                if (item != null && !item.isStrictCanonical()) {
+                    literal = mergeReverser.reverseToMinimizedOverlay(literal);
+                }
+                entries.add(literalPatchEntry(literal, i, context));
+            }
+            return entries;
+        }
         if (step == null || step.getChangeset() == null) {
             return java.util.Collections.emptyList();
         }

--- a/src/test/java/blue/coordination/processor/InheritedStaticUpdateDocumentTest.java
+++ b/src/test/java/blue/coordination/processor/InheritedStaticUpdateDocumentTest.java
@@ -1,0 +1,89 @@
+package blue.coordination.processor;
+
+import blue.language.Blue;
+import blue.language.NodeProvider;
+import blue.language.model.Node;
+import blue.language.processor.DocumentProcessingResult;
+import blue.language.processor.ProcessorStatus;
+import blue.language.processor.registry.RuntimeBlueIds;
+import blue.language.provider.BasicNodeProvider;
+import blue.language.provider.SequentialNodeProvider;
+import blue.language.utils.NodeProviderWrapper;
+import blue.repo.BlueRepository;
+import blue.repo.coordination.DocumentStatus;
+import blue.repo.coordination.SequentialWorkflow;
+import blue.repo.coordination.StatusInProgress;
+import blue.repo.coordination.UpdateDocument;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InheritedStaticUpdateDocumentTest {
+
+    @Test
+    void inheritedStaticPatchWritesItsAuthoredValueFromTheResolvedContractView() {
+        Blue blue = BlueRepository.latest().configure(new Blue());
+        NodeProvider repositoryProvider = blue.getNodeProvider();
+        BasicNodeProvider documentTypes = new BasicNodeProvider();
+        documentTypes.addSingleNodes(documentType(new Node()
+                .name("Authored status")
+                .type(reference(StatusInProgress.blueId()))));
+        String documentTypeId = documentTypes.getBlueIdByName("Inherited Static Update Document");
+        blue.nodeProvider(new SequentialNodeProvider(
+                NodeProviderWrapper.unverified(documentTypes),
+                repositoryProvider));
+        CoordinationProcessors.registerWith(blue);
+
+        DocumentProcessingResult result = blue.initializeDocument(
+                blue.resolveToSnapshot(new Node().type(reference(documentTypeId))));
+
+        assertEquals(ProcessorStatus.SUCCESS, result.status(), result.failureReason());
+        assertNull(result.failureReason());
+        Node canonicalStatus = result.canonicalDocument().getProperties().get("status");
+        assertEquals(StatusInProgress.blueId(), canonicalStatus.getType().getBlueId());
+        assertEquals("Authored status", canonicalStatus.getName());
+        assertEquals("active", result.resolvedDocument().getAsText("/status/mode"));
+        assertNull(canonicalStatus.getDescription(),
+                "metadata inherited by Json Patch Entry.val must not become document content");
+    }
+
+    @Test
+    void authoredReferenceWithSiblingPayloadRemainsInvalid() {
+        BasicNodeProvider documentTypes = new BasicNodeProvider();
+
+        IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
+                () -> documentTypes.addSingleNodes(documentType(new Node()
+                        .blueId(StatusInProgress.blueId())
+                        .properties("mode", new Node().value("tampered")))));
+
+        assertTrue(failure.getMessage().contains(
+                "\"blueId\" nodes must be reference-only and cannot contain sibling fields"));
+    }
+
+    private static Node documentType(Node patchValue) {
+        return new Node()
+                .name("Inherited Static Update Document")
+                .properties("status", new Node().type(reference(DocumentStatus.blueId())))
+                .contracts(new Node()
+                        .properties("lifecycle", new Node()
+                                .type(reference(RuntimeBlueIds.LIFECYCLE_EVENT_CHANNEL))
+                                .properties("event", new Node()
+                                        .type(reference(RuntimeBlueIds.DOCUMENT_PROCESSING_INITIATED))))
+                        .properties("initializeStatus", new Node()
+                                .type(reference(SequentialWorkflow.blueId()))
+                                .properties("channel", new Node().value("lifecycle"))
+                                .properties("steps", new Node().items(new Node()
+                                        .type(reference(UpdateDocument.blueId()))
+                                        .properties("changeset", new Node().items(new Node()
+                                                .properties("op", new Node().value("replace"))
+                                                .properties("path", new Node().value("/status"))
+                                                .properties("val", patchValue)))))));
+    }
+
+    private static Node reference(String blueId) {
+        return new Node().blueId(blueId);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize resolved static Update Document entries before applying them to selected document state
- preserve authored metadata while removing inherited Json Patch Entry metadata
- retain strict rejection of invalid authored BlueId sibling payloads

## Verification
- CI=true ./gradlew clean check jmhClasses
- real MyOS Document Session Bootstrap initialization via ResolvedSnapshot